### PR TITLE
feat: Order 및 Payment API 구현 (Mock)

### DIFF
--- a/prisma/migrations/20251021071301_add_order_models/migration.sql
+++ b/prisma/migrations/20251021071301_add_order_models/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'PAID', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "orders" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "total_price" INTEGER NOT NULL,
+    "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_items" (
+    "id" TEXT NOT NULL,
+    "order_id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "course_title" TEXT NOT NULL,
+    "course_slug" TEXT NOT NULL,
+    "course_thumbnail" TEXT,
+    "price" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "orders_user_id_idx" ON "orders"("user_id");
+
+-- CreateIndex
+CREATE INDEX "orders_status_idx" ON "orders"("status");
+
+-- CreateIndex
+CREATE INDEX "order_items_order_id_idx" ON "order_items"("order_id");
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251021073411_add_payment_and_enrollment_models/migration.sql
+++ b/prisma/migrations/20251021073411_add_payment_and_enrollment_models/migration.sql
@@ -1,0 +1,74 @@
+-- CreateTable
+CREATE TABLE "payments" (
+    "id" TEXT NOT NULL,
+    "payment_id" TEXT NOT NULL,
+    "order_id" TEXT NOT NULL,
+    "transaction_id" TEXT,
+    "amount" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'KRW',
+    "payment_method" TEXT NOT NULL,
+    "pg_provider" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'READY',
+    "failure_reason" TEXT,
+    "paid_at" TIMESTAMP(3),
+    "cancelled_at" TIMESTAMP(3),
+    "virtual_account_number" TEXT,
+    "virtual_account_bank" TEXT,
+    "virtual_account_holder" TEXT,
+    "virtual_account_expiry" TIMESTAMP(3),
+    "portone_data" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "payments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "enrollments" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "enrolled_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3),
+    "last_accessed_at" TIMESTAMP(3),
+    "progress" INTEGER NOT NULL DEFAULT 0,
+    "is_completed" BOOLEAN NOT NULL DEFAULT false,
+    "completed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "enrollments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "payments_payment_id_key" ON "payments"("payment_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "payments_order_id_key" ON "payments"("order_id");
+
+-- CreateIndex
+CREATE INDEX "payments_payment_id_idx" ON "payments"("payment_id");
+
+-- CreateIndex
+CREATE INDEX "payments_status_idx" ON "payments"("status");
+
+-- CreateIndex
+CREATE INDEX "payments_transaction_id_idx" ON "payments"("transaction_id");
+
+-- CreateIndex
+CREATE INDEX "enrollments_user_id_idx" ON "enrollments"("user_id");
+
+-- CreateIndex
+CREATE INDEX "enrollments_course_id_idx" ON "enrollments"("course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "enrollments_user_id_course_id_key" ON "enrollments"("user_id", "course_id");
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,12 @@ enum CourseStatus {
   OPEN
 }
 
+enum OrderStatus {
+  PENDING   // 결제 대기
+  PAID      // 결제 완료
+  CANCELLED // 취소됨
+}
+
 model User {
   id              String   @id @default(cuid())
   nickname        String   @map("nickname")
@@ -37,6 +43,7 @@ model User {
 
   courses   Course[]   // 강사가 만든 코스들
   cartItems CartItem[] // 장바구니 아이템들
+  orders    Order[]    // 주문 내역
 
   @@index([email])
   @@map("users")
@@ -113,4 +120,38 @@ model CartItem {
 
   @@unique([userId, courseId])
   @@map("cart_items")
+}
+
+// 주문
+model Order {
+  id         String      @id @default(uuid())
+  userId     String      @map("user_id")
+  totalPrice Int         @map("total_price")
+  status     OrderStatus @default(PENDING)
+  createdAt  DateTime    @default(now()) @map("created_at")
+  updatedAt  DateTime    @updatedAt @map("updated_at")
+
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  orderItems OrderItem[]
+
+  @@index([userId])
+  @@index([status])
+  @@map("orders")
+}
+
+// 주문 아이템 (주문 시점의 코스 정보 스냅샷)
+model OrderItem {
+  id              String   @id @default(uuid())
+  orderId         String   @map("order_id")
+  courseId        String   @map("course_id") // FK 아님, 참조용
+  courseTitle     String   @map("course_title")
+  courseSlug      String   @map("course_slug")
+  courseThumbnail String?  @map("course_thumbnail")
+  price           Int
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  @@index([orderId])
+  @@map("order_items")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ enum OrderStatus {
   CANCELLED // 취소됨
 }
 
+
 model User {
   id              String   @id @default(cuid())
   nickname        String   @map("nickname")
@@ -41,9 +42,10 @@ model User {
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at") // Soft Delete Column
 
-  courses   Course[]   // 강사가 만든 코스들
-  cartItems CartItem[] // 장바구니 아이템들
-  orders    Order[]    // 주문 내역
+  courses     Course[]     // 강사가 만든 코스들
+  cartItems   CartItem[]   // 장바구니 아이템들
+  orders      Order[]      // 주문 내역
+  enrollments Enrollment[] // 수강 내역
 
   @@index([email])
   @@map("users")
@@ -64,9 +66,10 @@ model Course {
   updatedAt    DateTime     @updatedAt @map("updated_at")
   deletedAt    DateTime?    @map("deleted_at") // Soft Delete Column
 
-  sections  Section[]
-  lectures  Lecture[]
-  cartItems CartItem[] // 장바구니에 담긴 아이템들
+  sections    Section[]
+  lectures    Lecture[]
+  cartItems   CartItem[]   // 장바구니에 담긴 아이템들
+  enrollments Enrollment[] // 수강 내역
 
   @@index([slug])
   @@map("courses")
@@ -133,6 +136,7 @@ model Order {
 
   user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   orderItems OrderItem[]
+  payment    Payment?
 
   @@index([userId])
   @@index([status])
@@ -154,4 +158,59 @@ model OrderItem {
 
   @@index([orderId])
   @@map("order_items")
+}
+
+// 결제 모델 (포트원 연동용)
+model Payment {
+  id                   String    @id @default(uuid())
+  paymentId            String    @unique @map("payment_id") // 포트원 결제 ID
+  orderId              String    @unique @map("order_id")
+  transactionId        String?   @map("transaction_id") // 포트원 거래 ID
+  amount               Int       @map("amount")
+  currency             String    @default("KRW") // 화폐
+  paymentMethod        String    @map("payment_method") // 결제 수단 (CARD, VIRTUAL_ACCOUNT, etc)
+  pgProvider           String?   @map("pg_provider") // PG사 (tosspayments, etc)
+  status               String    @default("READY") // READY, PAID, FAILED, CANCELLED
+  failureReason        String?   @map("failure_reason")
+  paidAt               DateTime? @map("paid_at")
+  cancelledAt          DateTime? @map("cancelled_at")
+  // 가상계좌 정보
+  virtualAccountNumber String?   @map("virtual_account_number")
+  virtualAccountBank   String?   @map("virtual_account_bank")
+  virtualAccountHolder String?   @map("virtual_account_holder")
+  virtualAccountExpiry DateTime? @map("virtual_account_expiry")
+  // 포트원 웹훅 정보
+  portoneData          Json?     @map("portone_data") // 포트원에서 받은 전체 데이터
+  createdAt            DateTime  @default(now()) @map("created_at")
+  updatedAt            DateTime  @updatedAt @map("updated_at")
+
+  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  @@index([paymentId])
+  @@index([status])
+  @@index([transactionId])
+  @@map("payments")
+}
+
+// 수강 정보
+model Enrollment {
+  id                String    @id @default(uuid())
+  userId            String    @map("user_id")
+  courseId          String    @map("course_id")
+  enrolledAt        DateTime  @default(now()) @map("enrolled_at") // 수강 시작 시각
+  expiresAt         DateTime? @map("expires_at") // 수강 만료 시각 (null이면 평생)
+  lastAccessedAt    DateTime? @map("last_accessed_at") // 마지막 접근 시각
+  progress          Int       @default(0) // 진행률 (0-100)
+  isCompleted       Boolean   @default(false) @map("is_completed") // 완료 여부
+  completedAt       DateTime? @map("completed_at") // 완료 시각
+  createdAt         DateTime  @default(now()) @map("created_at")
+  updatedAt         DateTime  @updatedAt @map("updated_at")
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, courseId])
+  @@index([userId])
+  @@index([courseId])
+  @@map("enrollments")
 }

--- a/src/api/controller/orders/order.controller.ts
+++ b/src/api/controller/orders/order.controller.ts
@@ -1,0 +1,112 @@
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AccessTokenGuard } from '@/api/controller/auth/access-token.guard';
+import { CurrentUser, type CurrentUserPayload } from '@/api/controller/auth/current-user.decorator';
+import {
+  createPaginatedResponse,
+  createSuccessResponse,
+  type PaginatedResponse,
+  type SuccessResponse,
+} from '@/api/support/response';
+
+import { OrderService } from '@/domain/orders/order.service';
+
+import { GetOrdersRequest } from './order.request';
+import { OrderResponse } from './order.response';
+
+@ApiTags('orders')
+@Controller('orders')
+@UseGuards(AccessTokenGuard)
+@ApiBearerAuth()
+export class OrderController {
+  constructor(private readonly orderService: OrderService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: '주문 생성 (장바구니 기반)' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: '주문 생성 성공',
+    type: OrderResponse,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: '장바구니가 비어있음',
+  })
+  async createOrder(@CurrentUser() user: CurrentUserPayload): Promise<SuccessResponse<OrderResponse>> {
+    const order = await this.orderService.createOrder(user.userId);
+    return createSuccessResponse(OrderResponse.from(order));
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '주문 목록 조회' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '주문 목록 조회 성공',
+    type: [OrderResponse],
+  })
+  async getOrders(
+    @CurrentUser() user: CurrentUserPayload,
+    @Query() query: GetOrdersRequest,
+  ): Promise<PaginatedResponse<OrderResponse>> {
+    const { page = 1, pageSize = 10, status } = query;
+
+    const result = await this.orderService.getOrders(user.userId, page, pageSize, status ? { status } : undefined);
+
+    return createPaginatedResponse(
+      result.orders.map((order) => OrderResponse.from(order)),
+      result.totalCount,
+      page,
+      pageSize,
+    );
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '주문 상세 조회' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '주문 상세 조회 성공',
+    type: OrderResponse,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '주문을 찾을 수 없음',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: '다른 사용자의 주문',
+  })
+  async getOrderById(
+    @CurrentUser() user: CurrentUserPayload,
+    @Param('id') orderId: string,
+  ): Promise<SuccessResponse<OrderResponse>> {
+    const order = await this.orderService.getOrderById(user.userId, orderId);
+    return createSuccessResponse(OrderResponse.from(order));
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '주문 취소' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: '주문 취소 성공',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '주문을 찾을 수 없음',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'PENDING 상태가 아닌 주문',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: '다른 사용자의 주문',
+  })
+  async cancelOrder(@CurrentUser() user: CurrentUserPayload, @Param('id') orderId: string): Promise<void> {
+    await this.orderService.cancelOrder(user.userId, orderId);
+  }
+}

--- a/src/api/controller/orders/order.request.ts
+++ b/src/api/controller/orders/order.request.ts
@@ -1,0 +1,42 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
+import { OrderStatus } from '@prisma/client';
+
+export class GetOrdersRequest {
+  @ApiProperty({
+    description: '페이지 번호',
+    example: 1,
+    required: false,
+    default: 1,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({
+    description: '페이지 크기',
+    example: 10,
+    required: false,
+    default: 10,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  pageSize?: number = 10;
+
+  @ApiProperty({
+    description: '주문 상태 필터',
+    enum: OrderStatus,
+    required: false,
+  })
+  @IsEnum(OrderStatus)
+  @IsOptional()
+  status?: OrderStatus;
+}

--- a/src/api/controller/orders/order.response.ts
+++ b/src/api/controller/orders/order.response.ts
@@ -1,0 +1,120 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { OrderStatus } from '@prisma/client';
+
+import { Order } from '@/domain/orders/order';
+import { OrderItem } from '@/domain/orders/order-item';
+
+export class OrderItemResponse {
+  @ApiProperty({
+    description: '주문 아이템 ID',
+    example: 'clx1234567890',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '코스 ID',
+    example: 'clx0987654321',
+  })
+  courseId: string;
+
+  @ApiProperty({
+    description: '코스 제목 (주문 시점)',
+    example: 'NestJS 완벽 가이드',
+  })
+  courseTitle: string;
+
+  @ApiProperty({
+    description: '코스 슬러그 (주문 시점)',
+    example: 'nestjs-fundamentals',
+  })
+  courseSlug: string;
+
+  @ApiProperty({
+    description: '코스 썸네일 (주문 시점)',
+    example: 'https://example.com/thumbnail.jpg',
+    nullable: true,
+  })
+  courseThumbnail: string | null;
+
+  @ApiProperty({
+    description: '가격 (주문 시점)',
+    example: 50000,
+  })
+  price: number;
+
+  @ApiProperty({
+    description: '생성 시각',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  createdAt: Date;
+
+  static from(orderItem: OrderItem): OrderItemResponse {
+    const response = new OrderItemResponse();
+    response.id = orderItem.id;
+    response.courseId = orderItem.courseId;
+    response.courseTitle = orderItem.courseTitle;
+    response.courseSlug = orderItem.courseSlug;
+    response.courseThumbnail = orderItem.courseThumbnail;
+    response.price = orderItem.price;
+    response.createdAt = orderItem.createdAt;
+    return response;
+  }
+}
+
+export class OrderResponse {
+  @ApiProperty({
+    description: '주문 ID',
+    example: 'clx1234567890',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '사용자 ID',
+    example: 'usr_1234567890',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: '총 주문 금액',
+    example: 150000,
+  })
+  totalPrice: number;
+
+  @ApiProperty({
+    description: '주문 상태',
+    enum: OrderStatus,
+    example: OrderStatus.PENDING,
+  })
+  status: OrderStatus;
+
+  @ApiProperty({
+    description: '주문 아이템 목록',
+    type: [OrderItemResponse],
+  })
+  orderItems: OrderItemResponse[];
+
+  @ApiProperty({
+    description: '주문 생성 시각',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '주문 수정 시각',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  updatedAt: Date;
+
+  static from(order: Order): OrderResponse {
+    const response = new OrderResponse();
+    response.id = order.id;
+    response.userId = order.userId;
+    response.totalPrice = order.totalPrice;
+    response.status = order.status;
+    response.orderItems = order.orderItems.map((item) => OrderItemResponse.from(item));
+    response.createdAt = order.createdAt;
+    response.updatedAt = order.updatedAt;
+    return response;
+  }
+}

--- a/src/api/controller/payments/payment.controller.ts
+++ b/src/api/controller/payments/payment.controller.ts
@@ -1,0 +1,64 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { createSuccessResponse, type SuccessResponse } from '@/api/support/response';
+
+import { PaymentService } from '@/domain/payments/payment.service';
+
+import { VerifyPaymentRequest, WebhookRequest } from './payment.request';
+import { PaymentResponse } from './payment.response';
+
+@ApiTags('payments')
+@Controller('payments')
+export class PaymentController {
+  constructor(private readonly paymentService: PaymentService) {}
+
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '결제 검증 (Mock - 무조건 성공)',
+    description:
+      'Mock 환경에서 결제를 검증하고 주문 상태를 변경하며 수강 정보를 등록합니다. 실제 환경에서는 포트원 API를 호출합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '결제 검증 성공',
+    type: PaymentResponse,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '주문을 찾을 수 없음',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: '잘못된 요청 (이미 결제된 주문, PENDING 상태가 아닌 주문 등)',
+  })
+  async verifyPayment(@Body() request: VerifyPaymentRequest): Promise<SuccessResponse<PaymentResponse>> {
+    const payment = await this.paymentService.verifyPayment(request.paymentId, request.orderId);
+    return createSuccessResponse(PaymentResponse.from(payment));
+  }
+
+  @Post('webhook')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '결제 웹훅 (Mock)',
+    description: 'Mock 환경에서 결제 웹훅을 처리합니다. 실제 환경에서는 포트원 웹훅 서명을 검증합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '웹훅 처리 성공',
+    type: PaymentResponse,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '결제 정보를 찾을 수 없음',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: '지원하지 않는 결제 상태',
+  })
+  async handleWebhook(@Body() request: WebhookRequest): Promise<SuccessResponse<PaymentResponse>> {
+    const payment = await this.paymentService.handleWebhook(request.paymentId, request.status, request.transactionId);
+    return createSuccessResponse(PaymentResponse.from(payment));
+  }
+}

--- a/src/api/controller/payments/payment.request.ts
+++ b/src/api/controller/payments/payment.request.ts
@@ -1,0 +1,48 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VerifyPaymentRequest {
+  @ApiProperty({
+    description: '포트원 결제 ID (Mock에서는 임의 값)',
+    example: 'payment_mock_1234567890',
+  })
+  @IsString()
+  @IsNotEmpty()
+  paymentId: string;
+
+  @ApiProperty({
+    description: '주문 ID',
+    example: 'clx1234567890',
+  })
+  @IsString()
+  @IsNotEmpty()
+  orderId: string;
+}
+
+export class WebhookRequest {
+  @ApiProperty({
+    description: '포트원 결제 ID',
+    example: 'payment_mock_1234567890',
+  })
+  @IsString()
+  @IsNotEmpty()
+  paymentId: string;
+
+  @ApiProperty({
+    description: '결제 상태',
+    example: 'PAID',
+    enum: ['READY', 'PAID', 'FAILED', 'CANCELLED'],
+  })
+  @IsString()
+  @IsNotEmpty()
+  status: string;
+
+  @ApiProperty({
+    description: '트랜잭션 ID (선택)',
+    example: 'tx_mock_1234567890',
+    required: false,
+  })
+  @IsString()
+  transactionId?: string;
+}

--- a/src/api/controller/payments/payment.response.ts
+++ b/src/api/controller/payments/payment.response.ts
@@ -1,0 +1,98 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Payment } from '@/domain/payments/payment';
+
+export class PaymentResponse {
+  @ApiProperty({
+    description: '결제 ID',
+    example: 'clx1234567890',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '포트원 결제 ID',
+    example: 'payment_mock_1234567890',
+  })
+  paymentId: string;
+
+  @ApiProperty({
+    description: '주문 ID',
+    example: 'clx0987654321',
+  })
+  orderId: string;
+
+  @ApiProperty({
+    description: '트랜잭션 ID',
+    example: 'tx_mock_1234567890',
+    nullable: true,
+  })
+  transactionId: string | null;
+
+  @ApiProperty({
+    description: '결제 금액',
+    example: 150000,
+  })
+  amount: number;
+
+  @ApiProperty({
+    description: '화폐',
+    example: 'KRW',
+  })
+  currency: string;
+
+  @ApiProperty({
+    description: '결제 수단',
+    example: 'MOCK',
+  })
+  paymentMethod: string;
+
+  @ApiProperty({
+    description: 'PG사',
+    example: 'MOCK_PG',
+    nullable: true,
+  })
+  pgProvider: string | null;
+
+  @ApiProperty({
+    description: '결제 상태',
+    example: 'PAID',
+    enum: ['READY', 'PAID', 'FAILED', 'CANCELLED'],
+  })
+  status: string;
+
+  @ApiProperty({
+    description: '결제 완료 시각',
+    example: '2024-01-01T00:00:00.000Z',
+    nullable: true,
+  })
+  paidAt: Date | null;
+
+  @ApiProperty({
+    description: '생성 시각',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '수정 시각',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  updatedAt: Date;
+
+  static from(payment: Payment): PaymentResponse {
+    const response = new PaymentResponse();
+    response.id = payment.id;
+    response.paymentId = payment.paymentId;
+    response.orderId = payment.orderId;
+    response.transactionId = payment.transactionId;
+    response.amount = payment.amount;
+    response.currency = payment.currency;
+    response.paymentMethod = payment.paymentMethod;
+    response.pgProvider = payment.pgProvider;
+    response.status = payment.status;
+    response.paidAt = payment.paidAt;
+    response.createdAt = payment.createdAt;
+    response.updatedAt = payment.updatedAt;
+    return response;
+  }
+}

--- a/src/domain/enrollments/enrollment.repository.ts
+++ b/src/domain/enrollments/enrollment.repository.ts
@@ -1,0 +1,13 @@
+import { Enrollment } from './enrollment';
+import { NewEnrollment } from './new-enrollment';
+
+export const ENROLLMENT_REPOSITORY = Symbol('ENROLLMENT_REPOSITORY');
+
+export interface IEnrollmentRepository {
+  save(enrollment: NewEnrollment): Promise<Enrollment>;
+  findById(id: string): Promise<Enrollment | null>;
+  findByUserIdAndCourseId(userId: string, courseId: string): Promise<Enrollment | null>;
+  findAllByUserId(userId: string): Promise<Enrollment[]>;
+  findAllByCourseId(courseId: string): Promise<Enrollment[]>;
+  exists(userId: string, courseId: string): Promise<boolean>;
+}

--- a/src/domain/enrollments/enrollment.ts
+++ b/src/domain/enrollments/enrollment.ts
@@ -1,0 +1,15 @@
+export class Enrollment {
+  constructor(
+    public readonly id: string,
+    public readonly userId: string,
+    public readonly courseId: string,
+    public readonly enrolledAt: Date,
+    public readonly expiresAt: Date | null,
+    public readonly lastAccessedAt: Date | null,
+    public readonly progress: number,
+    public readonly isCompleted: boolean,
+    public readonly completedAt: Date | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/src/domain/enrollments/new-enrollment.ts
+++ b/src/domain/enrollments/new-enrollment.ts
@@ -1,0 +1,7 @@
+export class NewEnrollment {
+  constructor(
+    public readonly userId: string,
+    public readonly courseId: string,
+    public readonly expiresAt: Date | null = null, // null이면 평생 수강
+  ) {}
+}

--- a/src/domain/orders/new-order-item.ts
+++ b/src/domain/orders/new-order-item.ts
@@ -1,0 +1,21 @@
+export class NewOrderItem {
+  courseId: string;
+  courseTitle: string;
+  courseSlug: string;
+  courseThumbnail: string | null;
+  price: number;
+
+  constructor(
+    courseId: string,
+    courseTitle: string,
+    courseSlug: string,
+    courseThumbnail: string | null,
+    price: number,
+  ) {
+    this.courseId = courseId;
+    this.courseTitle = courseTitle;
+    this.courseSlug = courseSlug;
+    this.courseThumbnail = courseThumbnail;
+    this.price = price;
+  }
+}

--- a/src/domain/orders/new-order.ts
+++ b/src/domain/orders/new-order.ts
@@ -1,0 +1,13 @@
+import { NewOrderItem } from './new-order-item';
+
+export class NewOrder {
+  userId: string;
+  totalPrice: number;
+  orderItems: NewOrderItem[];
+
+  constructor(userId: string, totalPrice: number, orderItems: NewOrderItem[]) {
+    this.userId = userId;
+    this.totalPrice = totalPrice;
+    this.orderItems = orderItems;
+  }
+}

--- a/src/domain/orders/order-item.ts
+++ b/src/domain/orders/order-item.ts
@@ -1,0 +1,30 @@
+export class OrderItem {
+  id: string;
+  orderId: string;
+  courseId: string;
+  courseTitle: string;
+  courseSlug: string;
+  courseThumbnail: string | null;
+  price: number;
+  createdAt: Date;
+
+  constructor(
+    id: string,
+    orderId: string,
+    courseId: string,
+    courseTitle: string,
+    courseSlug: string,
+    courseThumbnail: string | null,
+    price: number,
+    createdAt: Date,
+  ) {
+    this.id = id;
+    this.orderId = orderId;
+    this.courseId = courseId;
+    this.courseTitle = courseTitle;
+    this.courseSlug = courseSlug;
+    this.courseThumbnail = courseThumbnail;
+    this.price = price;
+    this.createdAt = createdAt;
+  }
+}

--- a/src/domain/orders/order.repository.ts
+++ b/src/domain/orders/order.repository.ts
@@ -1,0 +1,23 @@
+import { OrderStatus } from '@prisma/client';
+
+import { NewOrder } from './new-order';
+import { Order } from './order';
+
+export const ORDER_REPOSITORY = Symbol('ORDER_REPOSITORY');
+
+export interface OrderFilter {
+  status?: OrderStatus;
+}
+
+export interface OrderListResult {
+  orders: Order[];
+  totalCount: number;
+}
+
+export interface IOrderRepository {
+  save(order: NewOrder): Promise<Order>;
+  findById(id: string): Promise<Order | null>;
+  findAllByUserId(userId: string, page: number, pageSize: number, filter?: OrderFilter): Promise<OrderListResult>;
+  updateStatus(id: string, status: OrderStatus): Promise<Order>;
+  cancel(id: string): Promise<void>;
+}

--- a/src/domain/orders/order.service.ts
+++ b/src/domain/orders/order.service.ts
@@ -1,0 +1,95 @@
+import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+import { OrderStatus } from '@prisma/client';
+
+import { CART_ITEM_REPOSITORY, type ICartItemRepository } from '@/domain/cart/cart-item.repository';
+
+import { NewOrder } from './new-order';
+import { NewOrderItem } from './new-order-item';
+import { Order } from './order';
+import { ORDER_REPOSITORY, type IOrderRepository, type OrderFilter, type OrderListResult } from './order.repository';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    @Inject(ORDER_REPOSITORY)
+    private readonly orderRepository: IOrderRepository,
+    @Inject(CART_ITEM_REPOSITORY)
+    private readonly cartItemRepository: ICartItemRepository,
+  ) {}
+
+  async createOrder(userId: string): Promise<Order> {
+    // 장바구니 아이템 조회
+    const cartItems = await this.cartItemRepository.findAllByUserId(userId);
+
+    if (cartItems.length === 0) {
+      throw new BadRequestException('장바구니가 비어있습니다.');
+    }
+
+    // 장바구니 아이템들을 OrderItem으로 변환 (스냅샷)
+    const orderItems = cartItems.map((cartItem) => {
+      if (!cartItem.course) {
+        throw new Error('Cart item must include course information');
+      }
+
+      return new NewOrderItem(
+        cartItem.course.id,
+        cartItem.course.title,
+        cartItem.course.slug,
+        cartItem.course.thumbnailUrl,
+        cartItem.course.price,
+      );
+    });
+
+    // 총 금액 계산
+    const totalPrice = orderItems.reduce((sum, item) => sum + item.price, 0);
+
+    // 주문 생성
+    const newOrder = new NewOrder(userId, totalPrice, orderItems);
+    const order = await this.orderRepository.save(newOrder);
+
+    // 장바구니 비우기
+    await Promise.all(cartItems.map((item) => this.cartItemRepository.delete(userId, item.courseId)));
+
+    return order;
+  }
+
+  async getOrderById(userId: string, orderId: string): Promise<Order> {
+    const order = await this.orderRepository.findById(orderId);
+
+    if (!order) {
+      throw new NotFoundException('주문을 찾을 수 없습니다.');
+    }
+
+    // 본인의 주문만 조회 가능
+    if (order.userId !== userId) {
+      throw new ForbiddenException('다른 사용자의 주문은 조회할 수 없습니다.');
+    }
+
+    return order;
+  }
+
+  async getOrders(userId: string, page: number, pageSize: number, filter?: OrderFilter): Promise<OrderListResult> {
+    return await this.orderRepository.findAllByUserId(userId, page, pageSize, filter);
+  }
+
+  async cancelOrder(userId: string, orderId: string): Promise<void> {
+    const order = await this.orderRepository.findById(orderId);
+
+    if (!order) {
+      throw new NotFoundException('주문을 찾을 수 없습니다.');
+    }
+
+    // 본인의 주문만 취소 가능
+    if (order.userId !== userId) {
+      throw new ForbiddenException('다른 사용자의 주문은 취소할 수 없습니다.');
+    }
+
+    // PENDING 상태일 때만 취소 가능
+    if (order.status !== OrderStatus.PENDING) {
+      throw new BadRequestException('결제 대기 중인 주문만 취소할 수 있습니다.');
+    }
+
+    await this.orderRepository.cancel(orderId);
+  }
+}

--- a/src/domain/orders/order.ts
+++ b/src/domain/orders/order.ts
@@ -1,0 +1,31 @@
+import { OrderStatus } from '@prisma/client';
+
+import { OrderItem } from './order-item';
+
+export class Order {
+  id: string;
+  userId: string;
+  totalPrice: number;
+  status: OrderStatus;
+  orderItems: OrderItem[];
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(
+    id: string,
+    userId: string,
+    totalPrice: number,
+    status: OrderStatus,
+    orderItems: OrderItem[],
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
+    this.id = id;
+    this.userId = userId;
+    this.totalPrice = totalPrice;
+    this.status = status;
+    this.orderItems = orderItems;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/domain/payments/new-payment.ts
+++ b/src/domain/payments/new-payment.ts
@@ -1,0 +1,11 @@
+export class NewPayment {
+  constructor(
+    public readonly paymentId: string,
+    public readonly orderId: string,
+    public readonly amount: number,
+    public readonly paymentMethod: string,
+    public readonly currency: string = 'KRW',
+    public readonly pgProvider: string | null = null,
+    public readonly transactionId: string | null = null,
+  ) {}
+}

--- a/src/domain/payments/payment.repository.ts
+++ b/src/domain/payments/payment.repository.ts
@@ -1,0 +1,13 @@
+import { NewPayment } from './new-payment';
+import { Payment } from './payment';
+
+export const PAYMENT_REPOSITORY = Symbol('PAYMENT_REPOSITORY');
+
+export interface IPaymentRepository {
+  save(payment: NewPayment): Promise<Payment>;
+  findById(id: string): Promise<Payment | null>;
+  findByPaymentId(paymentId: string): Promise<Payment | null>;
+  findByOrderId(orderId: string): Promise<Payment | null>;
+  updateStatus(id: string, status: string, paidAt?: Date, transactionId?: string, portoneData?: any): Promise<Payment>;
+  cancel(id: string, cancelledAt: Date, portoneData?: any): Promise<Payment>;
+}

--- a/src/domain/payments/payment.service.ts
+++ b/src/domain/payments/payment.service.ts
@@ -1,0 +1,165 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+import { OrderStatus } from '@prisma/client';
+
+import { ENROLLMENT_REPOSITORY, type IEnrollmentRepository } from '@/domain/enrollments/enrollment.repository';
+import { NewEnrollment } from '@/domain/enrollments/new-enrollment';
+import { ORDER_REPOSITORY, type IOrderRepository } from '@/domain/orders/order.repository';
+
+import { NewPayment } from './new-payment';
+import { Payment } from './payment';
+import { PAYMENT_REPOSITORY, type IPaymentRepository } from './payment.repository';
+
+@Injectable()
+export class PaymentService {
+  constructor(
+    @Inject(PAYMENT_REPOSITORY)
+    private readonly paymentRepository: IPaymentRepository,
+    @Inject(ORDER_REPOSITORY)
+    private readonly orderRepository: IOrderRepository,
+    @Inject(ENROLLMENT_REPOSITORY)
+    private readonly enrollmentRepository: IEnrollmentRepository,
+  ) {}
+
+  /**
+   * Mock 결제 검증 (무조건 성공)
+   * 실제 환경에서는 포트원 API를 호출하여 검증
+   */
+  async verifyPayment(paymentId: string, orderId: string): Promise<Payment> {
+    // 주문 확인
+    const order = await this.orderRepository.findById(orderId);
+    if (!order) {
+      throw new NotFoundException('주문을 찾을 수 없습니다.');
+    }
+
+    // 주문이 PENDING 상태인지 확인
+    if (order.status !== OrderStatus.PENDING) {
+      throw new BadRequestException('결제 대기 중인 주문이 아닙니다.');
+    }
+
+    // 기존 결제가 있는지 확인
+    const existingPayment = await this.paymentRepository.findByOrderId(orderId);
+    if (existingPayment) {
+      throw new BadRequestException('이미 결제가 진행된 주문입니다.');
+    }
+
+    // Mock 결제 생성 (무조건 성공)
+    const transactionId = `tx_mock_${Date.now()}`;
+    const newPayment = new NewPayment(
+      paymentId,
+      orderId,
+      order.totalPrice,
+      'MOCK', // Mock 결제 수단
+      'KRW',
+      'MOCK_PG', // Mock PG
+      transactionId,
+    );
+
+    const payment = await this.paymentRepository.save(newPayment);
+
+    // 결제 상태를 즉시 PAID로 업데이트
+    const paidAt = new Date();
+    const portoneData = {
+      gateway: 'MOCK',
+      verified: true,
+      verifiedAt: paidAt.toISOString(),
+    };
+
+    const paidPayment = await this.paymentRepository.updateStatus(
+      payment.id,
+      'PAID',
+      paidAt,
+      transactionId,
+      portoneData,
+    );
+
+    // 주문 상태를 PAID로 업데이트
+    await this.orderRepository.updateStatus(orderId, OrderStatus.PAID);
+
+    // 수강 정보 등록
+    await this.createEnrollmentsForOrder(
+      order.userId,
+      order.orderItems.map((item) => item.courseId),
+    );
+
+    return paidPayment;
+  }
+
+  /**
+   * Mock 웹훅 처리 (무조건 성공)
+   * 실제 환경에서는 포트원 웹훅 서명 검증 필요
+   */
+  async handleWebhook(paymentId: string, status: string, transactionId?: string): Promise<Payment> {
+    const payment = await this.paymentRepository.findByPaymentId(paymentId);
+    if (!payment) {
+      throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
+    }
+
+    // Mock 웹훅 데이터
+    const portoneData = {
+      gateway: 'MOCK',
+      webhook: true,
+      status,
+      receivedAt: new Date().toISOString(),
+    };
+
+    if (status === 'PAID') {
+      // 결제 완료
+      const paidAt = new Date();
+      const updatedPayment = await this.paymentRepository.updateStatus(
+        payment.id,
+        status,
+        paidAt,
+        transactionId || payment.transactionId || undefined,
+        portoneData,
+      );
+
+      // 주문 상태 업데이트
+      await this.orderRepository.updateStatus(payment.orderId, OrderStatus.PAID);
+
+      // 수강 정보 등록
+      const order = await this.orderRepository.findById(payment.orderId);
+      if (order) {
+        await this.createEnrollmentsForOrder(
+          order.userId,
+          order.orderItems.map((item) => item.courseId),
+        );
+      }
+
+      return updatedPayment;
+    } else if (status === 'FAILED') {
+      // 결제 실패
+      return await this.paymentRepository.updateStatus(payment.id, status, undefined, undefined, portoneData);
+    } else if (status === 'CANCELLED') {
+      // 결제 취소
+      const cancelledAt = new Date();
+      return await this.paymentRepository.cancel(payment.id, cancelledAt, portoneData);
+    }
+
+    throw new BadRequestException('지원하지 않는 결제 상태입니다.');
+  }
+
+  /**
+   * 주문의 코스들에 대한 수강 정보 생성
+   */
+  private async createEnrollmentsForOrder(userId: string, courseIds: string[]): Promise<void> {
+    for (const courseId of courseIds) {
+      // 이미 수강 중인지 확인
+      const exists = await this.enrollmentRepository.exists(userId, courseId);
+      if (exists) {
+        continue; // 이미 등록된 경우 스킵
+      }
+
+      // 수강 정보 생성 (평생 수강)
+      const newEnrollment = new NewEnrollment(userId, courseId, null);
+      await this.enrollmentRepository.save(newEnrollment);
+    }
+  }
+
+  /**
+   * 결제 정보 조회
+   */
+  async getPaymentByOrderId(orderId: string): Promise<Payment | null> {
+    return await this.paymentRepository.findByOrderId(orderId);
+  }
+}

--- a/src/domain/payments/payment.ts
+++ b/src/domain/payments/payment.ts
@@ -1,0 +1,23 @@
+export class Payment {
+  constructor(
+    public readonly id: string,
+    public readonly paymentId: string,
+    public readonly orderId: string,
+    public readonly transactionId: string | null,
+    public readonly amount: number,
+    public readonly currency: string,
+    public readonly paymentMethod: string,
+    public readonly pgProvider: string | null,
+    public readonly status: string,
+    public readonly failureReason: string | null,
+    public readonly paidAt: Date | null,
+    public readonly cancelledAt: Date | null,
+    public readonly virtualAccountNumber: string | null,
+    public readonly virtualAccountBank: string | null,
+    public readonly virtualAccountHolder: string | null,
+    public readonly virtualAccountExpiry: Date | null,
+    public readonly portoneData: any | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/src/infrastructure/database/prisma.enrollment.ts
+++ b/src/infrastructure/database/prisma.enrollment.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+
+import { Enrollment } from '@/domain/enrollments/enrollment';
+import { type IEnrollmentRepository } from '@/domain/enrollments/enrollment.repository';
+import { NewEnrollment } from '@/domain/enrollments/new-enrollment';
+
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class PrismaEnrollmentRepository implements IEnrollmentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async save(newEnrollment: NewEnrollment): Promise<Enrollment> {
+    const created = await this.prisma.enrollment.create({
+      data: {
+        userId: newEnrollment.userId,
+        courseId: newEnrollment.courseId,
+        expiresAt: newEnrollment.expiresAt,
+      },
+    });
+
+    return this.toEntity(created);
+  }
+
+  async findById(id: string): Promise<Enrollment | null> {
+    const enrollment = await this.prisma.enrollment.findUnique({
+      where: { id },
+    });
+
+    return enrollment ? this.toEntity(enrollment) : null;
+  }
+
+  async findByUserIdAndCourseId(userId: string, courseId: string): Promise<Enrollment | null> {
+    const enrollment = await this.prisma.enrollment.findUnique({
+      where: {
+        userId_courseId: {
+          userId,
+          courseId,
+        },
+      },
+    });
+
+    return enrollment ? this.toEntity(enrollment) : null;
+  }
+
+  async findAllByUserId(userId: string): Promise<Enrollment[]> {
+    const enrollments = await this.prisma.enrollment.findMany({
+      where: { userId },
+      orderBy: { enrolledAt: 'desc' },
+    });
+
+    return enrollments.map((e) => this.toEntity(e));
+  }
+
+  async findAllByCourseId(courseId: string): Promise<Enrollment[]> {
+    const enrollments = await this.prisma.enrollment.findMany({
+      where: { courseId },
+      orderBy: { enrolledAt: 'desc' },
+    });
+
+    return enrollments.map((e) => this.toEntity(e));
+  }
+
+  async exists(userId: string, courseId: string): Promise<boolean> {
+    const count = await this.prisma.enrollment.count({
+      where: {
+        userId,
+        courseId,
+      },
+    });
+
+    return count > 0;
+  }
+
+  private toEntity(enrollment: any): Enrollment {
+    return new Enrollment(
+      enrollment.id,
+      enrollment.userId,
+      enrollment.courseId,
+      enrollment.enrolledAt,
+      enrollment.expiresAt,
+      enrollment.lastAccessedAt,
+      enrollment.progress,
+      enrollment.isCompleted,
+      enrollment.completedAt,
+      enrollment.createdAt,
+      enrollment.updatedAt,
+    );
+  }
+}

--- a/src/infrastructure/database/prisma.order.ts
+++ b/src/infrastructure/database/prisma.order.ts
@@ -1,0 +1,211 @@
+import { Injectable } from '@nestjs/common';
+
+import { OrderStatus } from '@prisma/client';
+
+import { NewOrder } from '@/domain/orders/new-order';
+import { Order } from '@/domain/orders/order';
+import { OrderItem } from '@/domain/orders/order-item';
+import { type IOrderRepository, type OrderFilter, type OrderListResult } from '@/domain/orders/order.repository';
+
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class PrismaOrderRepository implements IOrderRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async save(newOrder: NewOrder): Promise<Order> {
+    const createdOrder = await this.prisma.order.create({
+      data: {
+        userId: newOrder.userId,
+        totalPrice: newOrder.totalPrice,
+        status: OrderStatus.PENDING,
+        orderItems: {
+          create: newOrder.orderItems.map((item) => ({
+            courseId: item.courseId,
+            courseTitle: item.courseTitle,
+            courseSlug: item.courseSlug,
+            courseThumbnail: item.courseThumbnail,
+            price: item.price,
+          })),
+        },
+      },
+      include: {
+        orderItems: true,
+      },
+    });
+
+    const orderItems = createdOrder.orderItems.map(
+      (item) =>
+        new OrderItem(
+          item.id,
+          item.orderId,
+          item.courseId,
+          item.courseTitle,
+          item.courseSlug,
+          item.courseThumbnail,
+          item.price,
+          item.createdAt,
+        ),
+    );
+
+    return new Order(
+      createdOrder.id,
+      createdOrder.userId,
+      createdOrder.totalPrice,
+      createdOrder.status,
+      orderItems,
+      createdOrder.createdAt,
+      createdOrder.updatedAt,
+    );
+  }
+
+  async findById(id: string): Promise<Order | null> {
+    const order = await this.prisma.order.findUnique({
+      where: { id },
+      include: {
+        orderItems: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+
+    if (!order) {
+      return null;
+    }
+
+    const orderItems = order.orderItems.map(
+      (item) =>
+        new OrderItem(
+          item.id,
+          item.orderId,
+          item.courseId,
+          item.courseTitle,
+          item.courseSlug,
+          item.courseThumbnail,
+          item.price,
+          item.createdAt,
+        ),
+    );
+
+    return new Order(
+      order.id,
+      order.userId,
+      order.totalPrice,
+      order.status,
+      orderItems,
+      order.createdAt,
+      order.updatedAt,
+    );
+  }
+
+  async findAllByUserId(
+    userId: string,
+    page: number,
+    pageSize: number,
+    filter?: OrderFilter,
+  ): Promise<OrderListResult> {
+    const skip = (page - 1) * pageSize;
+
+    const where = {
+      userId,
+      ...(filter?.status && { status: filter.status }),
+    };
+
+    const [orders, totalCount] = await Promise.all([
+      this.prisma.order.findMany({
+        where,
+        include: {
+          orderItems: {
+            orderBy: {
+              createdAt: 'asc',
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        skip,
+        take: pageSize,
+      }),
+      this.prisma.order.count({ where }),
+    ]);
+
+    const ordersWithItems = orders.map((order) => {
+      const orderItems = order.orderItems.map(
+        (item) =>
+          new OrderItem(
+            item.id,
+            item.orderId,
+            item.courseId,
+            item.courseTitle,
+            item.courseSlug,
+            item.courseThumbnail,
+            item.price,
+            item.createdAt,
+          ),
+      );
+
+      return new Order(
+        order.id,
+        order.userId,
+        order.totalPrice,
+        order.status,
+        orderItems,
+        order.createdAt,
+        order.updatedAt,
+      );
+    });
+
+    return {
+      orders: ordersWithItems,
+      totalCount,
+    };
+  }
+
+  async updateStatus(id: string, status: OrderStatus): Promise<Order> {
+    const updatedOrder = await this.prisma.order.update({
+      where: { id },
+      data: { status },
+      include: {
+        orderItems: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+
+    const orderItems = updatedOrder.orderItems.map(
+      (item) =>
+        new OrderItem(
+          item.id,
+          item.orderId,
+          item.courseId,
+          item.courseTitle,
+          item.courseSlug,
+          item.courseThumbnail,
+          item.price,
+          item.createdAt,
+        ),
+    );
+
+    return new Order(
+      updatedOrder.id,
+      updatedOrder.userId,
+      updatedOrder.totalPrice,
+      updatedOrder.status,
+      orderItems,
+      updatedOrder.createdAt,
+      updatedOrder.updatedAt,
+    );
+  }
+
+  async cancel(id: string): Promise<void> {
+    await this.prisma.order.update({
+      where: { id },
+      data: { status: OrderStatus.CANCELLED },
+    });
+  }
+}

--- a/src/infrastructure/database/prisma.payment.ts
+++ b/src/infrastructure/database/prisma.payment.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+
+import { NewPayment } from '@/domain/payments/new-payment';
+import { Payment } from '@/domain/payments/payment';
+import { type IPaymentRepository } from '@/domain/payments/payment.repository';
+
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class PrismaPaymentRepository implements IPaymentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async save(newPayment: NewPayment): Promise<Payment> {
+    const created = await this.prisma.payment.create({
+      data: {
+        paymentId: newPayment.paymentId,
+        orderId: newPayment.orderId,
+        amount: newPayment.amount,
+        currency: newPayment.currency,
+        paymentMethod: newPayment.paymentMethod,
+        pgProvider: newPayment.pgProvider,
+        transactionId: newPayment.transactionId,
+        status: 'READY',
+      },
+    });
+
+    return this.toEntity(created);
+  }
+
+  async findById(id: string): Promise<Payment | null> {
+    const payment = await this.prisma.payment.findUnique({
+      where: { id },
+    });
+
+    return payment ? this.toEntity(payment) : null;
+  }
+
+  async findByPaymentId(paymentId: string): Promise<Payment | null> {
+    const payment = await this.prisma.payment.findUnique({
+      where: { paymentId },
+    });
+
+    return payment ? this.toEntity(payment) : null;
+  }
+
+  async findByOrderId(orderId: string): Promise<Payment | null> {
+    const payment = await this.prisma.payment.findUnique({
+      where: { orderId },
+    });
+
+    return payment ? this.toEntity(payment) : null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: string,
+    paidAt?: Date,
+    transactionId?: string,
+    portoneData?: any,
+  ): Promise<Payment> {
+    const updated = await this.prisma.payment.update({
+      where: { id },
+      data: {
+        status,
+        ...(paidAt && { paidAt }),
+        ...(transactionId && { transactionId }),
+        ...(portoneData && { portoneData }),
+      },
+    });
+
+    return this.toEntity(updated);
+  }
+
+  async cancel(id: string, cancelledAt: Date, portoneData?: any): Promise<Payment> {
+    const updated = await this.prisma.payment.update({
+      where: { id },
+      data: {
+        status: 'CANCELLED',
+        cancelledAt,
+        ...(portoneData && { portoneData }),
+      },
+    });
+
+    return this.toEntity(updated);
+  }
+
+  private toEntity(payment: any): Payment {
+    return new Payment(
+      payment.id,
+      payment.paymentId,
+      payment.orderId,
+      payment.transactionId,
+      payment.amount,
+      payment.currency,
+      payment.paymentMethod,
+      payment.pgProvider,
+      payment.status,
+      payment.failureReason,
+      payment.paidAt,
+      payment.cancelledAt,
+      payment.virtualAccountNumber,
+      payment.virtualAccountBank,
+      payment.virtualAccountHolder,
+      payment.virtualAccountExpiry,
+      payment.portoneData,
+      payment.createdAt,
+      payment.updatedAt,
+    );
+  }
+}

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -8,6 +8,7 @@ import { CartModule } from './cart.module';
 import { CourseModule } from './course.module';
 import { LectureModule } from './lecture.module';
 import { OrderModule } from './order.module';
+import { PaymentModule } from './payment.module';
 import { PrismaModule } from './prisma.module';
 import { SectionModule } from './section.module';
 import { UserModule } from './user.module';
@@ -34,7 +35,16 @@ const externalModules = [
   PrismaModule,
 ];
 
-const internalModules = [UserModule, AuthModule, CourseModule, SectionModule, LectureModule, CartModule, OrderModule];
+const internalModules = [
+  UserModule,
+  AuthModule,
+  CourseModule,
+  SectionModule,
+  LectureModule,
+  CartModule,
+  OrderModule,
+  PaymentModule,
+];
 
 @Module({
   imports: [...externalModules, ...internalModules],

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from './auth.module';
 import { CartModule } from './cart.module';
 import { CourseModule } from './course.module';
 import { LectureModule } from './lecture.module';
+import { OrderModule } from './order.module';
 import { PrismaModule } from './prisma.module';
 import { SectionModule } from './section.module';
 import { UserModule } from './user.module';
@@ -33,7 +34,7 @@ const externalModules = [
   PrismaModule,
 ];
 
-const internalModules = [UserModule, AuthModule, CourseModule, SectionModule, LectureModule, CartModule];
+const internalModules = [UserModule, AuthModule, CourseModule, SectionModule, LectureModule, CartModule, OrderModule];
 
 @Module({
   imports: [...externalModules, ...internalModules],

--- a/src/modules/order.module.ts
+++ b/src/modules/order.module.ts
@@ -1,0 +1,26 @@
+import { forwardRef, Module } from '@nestjs/common';
+
+import { OrderController } from '@/api/controller/orders/order.controller';
+
+import { ORDER_REPOSITORY } from '@/domain/orders/order.repository';
+import { OrderService } from '@/domain/orders/order.service';
+
+import { PrismaOrderRepository } from '@/infrastructure/database/prisma.order';
+
+import { AuthModule } from './auth.module';
+import { CartModule } from './cart.module';
+import { PrismaModule } from './prisma.module';
+
+@Module({
+  imports: [PrismaModule, forwardRef(() => AuthModule), CartModule],
+  controllers: [OrderController],
+  providers: [
+    OrderService,
+    {
+      provide: ORDER_REPOSITORY,
+      useClass: PrismaOrderRepository,
+    },
+  ],
+  exports: [OrderService, ORDER_REPOSITORY],
+})
+export class OrderModule {}

--- a/src/modules/payment.module.ts
+++ b/src/modules/payment.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+
+import { PaymentController } from '@/api/controller/payments/payment.controller';
+
+import { ENROLLMENT_REPOSITORY } from '@/domain/enrollments/enrollment.repository';
+import { PAYMENT_REPOSITORY } from '@/domain/payments/payment.repository';
+import { PaymentService } from '@/domain/payments/payment.service';
+
+import { PrismaEnrollmentRepository } from '@/infrastructure/database/prisma.enrollment';
+import { PrismaPaymentRepository } from '@/infrastructure/database/prisma.payment';
+
+import { OrderModule } from './order.module';
+import { PrismaModule } from './prisma.module';
+
+@Module({
+  imports: [PrismaModule, OrderModule],
+  controllers: [PaymentController],
+  providers: [
+    PaymentService,
+    {
+      provide: PAYMENT_REPOSITORY,
+      useClass: PrismaPaymentRepository,
+    },
+    {
+      provide: ENROLLMENT_REPOSITORY,
+      useClass: PrismaEnrollmentRepository,
+    },
+  ],
+  exports: [PaymentService, PAYMENT_REPOSITORY, ENROLLMENT_REPOSITORY],
+})
+export class PaymentModule {}

--- a/test/integration/orders/order.controller.spec.ts
+++ b/test/integration/orders/order.controller.spec.ts
@@ -1,0 +1,581 @@
+import { TestHelper } from '@test/integration/test-helper';
+import request from 'supertest';
+
+import { HttpStatus, INestApplication } from '@nestjs/common';
+
+import { CourseStatus, OrderStatus } from '@prisma/client';
+
+describe('OrderController (Integration)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await TestHelper.initializeApp();
+  });
+
+  afterAll(async () => {
+    await TestHelper.closeApp();
+  });
+
+  beforeEach(async () => {
+    await TestHelper.cleanDatabase();
+  });
+
+  // 관리자 사용자 생성 및 로그인 헬퍼 함수
+  const createAdminUserAndLogin = async () => {
+    const prisma = TestHelper.getPrisma();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const bcrypt = require('bcrypt') as { hash: (password: string, salt: number) => Promise<string> };
+
+    const hashedPassword = await bcrypt.hash('AdminPassword123!', 10);
+    const admin = await prisma.user.create({
+      data: {
+        email: 'admin@example.com',
+        hashedPassword,
+        nickname: '관리자',
+        role: 'ADMIN',
+      },
+    });
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/signin')
+      .send({
+        email: 'admin@example.com',
+        password: 'AdminPassword123!',
+      })
+      .expect(HttpStatus.OK);
+
+    return {
+      adminId: admin.id,
+      accessToken: loginResponse.body.data.accessToken,
+    };
+  };
+
+  // 일반 사용자 생성 및 로그인 헬퍼 함수
+  const createUserAndLogin = async () => {
+    const response = await request(app.getHttpServer())
+      .post('/users')
+      .send({
+        email: 'user@example.com',
+        password: 'UserPassword123!',
+        nickname: '일반유저',
+      })
+      .expect(HttpStatus.CREATED);
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/signin')
+      .send({
+        email: 'user@example.com',
+        password: 'UserPassword123!',
+      })
+      .expect(HttpStatus.OK);
+
+    return {
+      userId: response.body.data.id,
+      accessToken: loginResponse.body.data.accessToken,
+    };
+  };
+
+  // 코스 생성 헬퍼 함수
+  const createCourse = async (adminAccessToken: string, slug: string, title: string, price: number = 50000) => {
+    const response = await request(app.getHttpServer())
+      .post('/courses')
+      .set('Authorization', `Bearer ${adminAccessToken}`)
+      .send({
+        slug,
+        title,
+        description: `${title} 설명`,
+        price,
+        status: CourseStatus.OPEN,
+      })
+      .expect(HttpStatus.CREATED);
+
+    return response.body.data;
+  };
+
+  // 장바구니에 코스 추가 헬퍼 함수
+  const addToCart = async (userAccessToken: string, courseId: string) => {
+    await request(app.getHttpServer())
+      .post('/cart')
+      .set('Authorization', `Bearer ${userAccessToken}`)
+      .send({ courseId })
+      .expect(HttpStatus.CREATED);
+  };
+
+  describe('POST /orders', () => {
+    it('장바구니에 있는 코스로 주문을 생성하면 201 상태코드와 주문 정보를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { userId, accessToken: userToken } = await createUserAndLogin();
+      const course1 = await createCourse(adminToken, 'course-1', 'NestJS 기초', 50000);
+      const course2 = await createCourse(adminToken, 'course-2', 'TypeScript 고급', 70000);
+
+      await addToCart(userToken, course1.id);
+      await addToCart(userToken, course2.id);
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      // then
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body.data).toMatchObject({
+        userId,
+        totalPrice: 120000,
+        status: OrderStatus.PENDING,
+      });
+      expect(response.body.data).toHaveProperty('id');
+      expect(response.body.data).toHaveProperty('orderItems');
+      expect(response.body.data.orderItems).toHaveLength(2);
+      // orderItems는 생성 순서대로 정렬됨
+      const orderItemsCourseIds = response.body.data.orderItems.map((item: any) => item.courseId);
+      expect(orderItemsCourseIds).toContain(course1.id);
+      expect(orderItemsCourseIds).toContain(course2.id);
+      expect(response.body.data).toHaveProperty('createdAt');
+      expect(response.body.data).toHaveProperty('updatedAt');
+
+      // 장바구니가 비워졌는지 확인
+      const cartResponse = await request(app.getHttpServer())
+        .get('/cart')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      expect(cartResponse.body.data).toHaveLength(0);
+    });
+
+    it('빈 장바구니로 주문 생성 시 400 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: userToken } = await createUserAndLogin();
+
+      // when & then
+      const response = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('장바구니가 비어있습니다');
+    });
+
+    it('인증되지 않은 사용자가 주문 생성 시 401 상태코드를 반환한다', async () => {
+      // when & then
+      await request(app.getHttpServer()).post('/orders').expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('GET /orders', () => {
+    it('사용자의 주문 목록을 조회하면 200 상태코드와 주문 목록을 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { userId, accessToken: userToken } = await createUserAndLogin();
+      const course1 = await createCourse(adminToken, 'course-1', '코스 1', 30000);
+      const course2 = await createCourse(adminToken, 'course-2', '코스 2', 40000);
+
+      // 첫 번째 주문
+      await addToCart(userToken, course1.id);
+      await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      // 두 번째 주문
+      await addToCart(userToken, course2.id);
+      await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      // then
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body.data).toHaveProperty('items');
+      expect(response.body.data.items).toHaveLength(2);
+      expect(response.body.data.items[0]).toMatchObject({
+        userId,
+        totalPrice: 40000,
+        status: OrderStatus.PENDING,
+      });
+      expect(response.body.data.items[1]).toMatchObject({
+        userId,
+        totalPrice: 30000,
+        status: OrderStatus.PENDING,
+      });
+      expect(response.body.data).toHaveProperty('pagination');
+      expect(response.body.data.pagination).toMatchObject({
+        totalCount: 2,
+        page: 1,
+        pageSize: 10,
+        totalPages: 1,
+      });
+    });
+
+    it('페이지네이션을 적용하여 주문 목록을 조회할 수 있다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { accessToken: userToken } = await createUserAndLogin();
+      const course = await createCourse(adminToken, 'course', '코스', 10000);
+
+      // 3개의 주문 생성
+      for (let i = 0; i < 3; i++) {
+        await addToCart(userToken, course.id);
+        await request(app.getHttpServer())
+          .post('/orders')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(HttpStatus.CREATED);
+      }
+
+      // when - 페이지 크기 2로 첫 페이지 조회
+      const response = await request(app.getHttpServer())
+        .get('/orders?page=1&pageSize=2')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      // then
+      expect(response.body.data.items).toHaveLength(2);
+      expect(response.body.data.pagination).toMatchObject({
+        totalCount: 3,
+        page: 1,
+        pageSize: 2,
+        totalPages: 2,
+      });
+    });
+
+    it('주문 상태로 필터링하여 조회할 수 있다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { accessToken: userToken } = await createUserAndLogin();
+      const course = await createCourse(adminToken, 'course', '코스', 10000);
+      const prisma = TestHelper.getPrisma();
+
+      // 주문 생성
+      await addToCart(userToken, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // 주문 상태를 PAID로 변경
+      await prisma.order.update({
+        where: { id: orderId },
+        data: { status: OrderStatus.PAID },
+      });
+
+      // 다른 PENDING 주문 생성
+      await addToCart(userToken, course.id);
+      await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      // when - PENDING 상태만 조회
+      const response = await request(app.getHttpServer())
+        .get(`/orders?status=${OrderStatus.PENDING}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      // then
+      expect(response.body.data.items).toHaveLength(1);
+      expect(response.body.data.items[0].status).toBe(OrderStatus.PENDING);
+    });
+
+    it('주문이 없는 경우 빈 배열을 반환한다', async () => {
+      // given
+      const { accessToken: userToken } = await createUserAndLogin();
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      // then
+      expect(response.body.data.items).toHaveLength(0);
+      expect(response.body.data.pagination).toMatchObject({
+        totalCount: 0,
+        page: 1,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    });
+
+    it('인증되지 않은 사용자가 주문 목록 조회 시 401 상태코드를 반환한다', async () => {
+      // when & then
+      await request(app.getHttpServer()).get('/orders').expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('GET /orders/:id', () => {
+    it('주문 ID로 주문 상세를 조회하면 200 상태코드와 주문 정보를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { userId, accessToken: userToken } = await createUserAndLogin();
+      const course = await createCourse(adminToken, 'course', 'NestJS 완벽 가이드', 100000);
+
+      await addToCart(userToken, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      // then
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body.data).toMatchObject({
+        id: orderId,
+        userId,
+        totalPrice: 100000,
+        status: OrderStatus.PENDING,
+      });
+      expect(response.body.data.orderItems).toHaveLength(1);
+      expect(response.body.data.orderItems[0]).toMatchObject({
+        courseId: course.id,
+        courseTitle: 'NestJS 완벽 가이드',
+        courseSlug: 'course',
+        price: 100000,
+      });
+    });
+
+    it('존재하지 않는 주문 ID로 조회 시 404 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: userToken } = await createUserAndLogin();
+      const nonExistentOrderId = 'non-existent-order-id';
+
+      // when & then
+      const response = await request(app.getHttpServer())
+        .get(`/orders/${nonExistentOrderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.NOT_FOUND);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('주문을 찾을 수 없습니다');
+    });
+
+    it('다른 사용자의 주문을 조회 시 403 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+
+      // 첫 번째 사용자가 주문 생성
+      await request(app.getHttpServer())
+        .post('/users')
+        .send({
+          email: 'user1@example.com',
+          password: 'UserPassword123!',
+          nickname: '유저1',
+        })
+        .expect(HttpStatus.CREATED);
+
+      const loginResponse1 = await request(app.getHttpServer())
+        .post('/auth/signin')
+        .send({
+          email: 'user1@example.com',
+          password: 'UserPassword123!',
+        })
+        .expect(HttpStatus.OK);
+
+      const user1Token = loginResponse1.body.data.accessToken;
+      const course = await createCourse(adminToken, 'course', '코스', 50000);
+
+      await addToCart(user1Token, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // 두 번째 사용자 생성
+      await request(app.getHttpServer())
+        .post('/users')
+        .send({
+          email: 'user2@example.com',
+          password: 'UserPassword123!',
+          nickname: '유저2',
+        })
+        .expect(HttpStatus.CREATED);
+
+      const loginResponse2 = await request(app.getHttpServer())
+        .post('/auth/signin')
+        .send({
+          email: 'user2@example.com',
+          password: 'UserPassword123!',
+        })
+        .expect(HttpStatus.OK);
+
+      const user2Token = loginResponse2.body.data.accessToken;
+
+      // when & then - 두 번째 사용자가 첫 번째 사용자의 주문 조회 시도
+      const response = await request(app.getHttpServer())
+        .get(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${user2Token}`)
+        .expect(HttpStatus.FORBIDDEN);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('다른 사용자의 주문은 조회할 수 없습니다');
+    });
+
+    it('인증되지 않은 사용자가 주문 상세 조회 시 401 상태코드를 반환한다', async () => {
+      // when & then
+      await request(app.getHttpServer()).get('/orders/some-order-id').expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('DELETE /orders/:id', () => {
+    it('PENDING 상태의 주문을 취소하면 204 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { accessToken: userToken } = await createUserAndLogin();
+      const course = await createCourse(adminToken, 'course', '코스', 50000);
+
+      await addToCart(userToken, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // when
+      await request(app.getHttpServer())
+        .delete(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.NO_CONTENT);
+
+      // then - 주문 상태가 CANCELLED로 변경되었는지 확인
+      const response = await request(app.getHttpServer())
+        .get(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data.status).toBe(OrderStatus.CANCELLED);
+    });
+
+    it('존재하지 않는 주문을 취소 시 404 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: userToken } = await createUserAndLogin();
+      const nonExistentOrderId = 'non-existent-order-id';
+
+      // when & then
+      const response = await request(app.getHttpServer())
+        .delete(`/orders/${nonExistentOrderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.NOT_FOUND);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('주문을 찾을 수 없습니다');
+    });
+
+    it('PENDING 상태가 아닌 주문을 취소 시 400 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+      const { accessToken: userToken } = await createUserAndLogin();
+      const course = await createCourse(adminToken, 'course', '코스', 50000);
+      const prisma = TestHelper.getPrisma();
+
+      await addToCart(userToken, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // 주문 상태를 PAID로 변경
+      await prisma.order.update({
+        where: { id: orderId },
+        data: { status: OrderStatus.PAID },
+      });
+
+      // when & then
+      const response = await request(app.getHttpServer())
+        .delete(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('결제 대기 중인 주문만 취소할 수 있습니다');
+    });
+
+    it('다른 사용자의 주문을 취소 시 403 상태코드를 반환한다', async () => {
+      // given
+      const { accessToken: adminToken } = await createAdminUserAndLogin();
+
+      // 첫 번째 사용자가 주문 생성
+      await request(app.getHttpServer())
+        .post('/users')
+        .send({
+          email: 'user1@example.com',
+          password: 'UserPassword123!',
+          nickname: '유저1',
+        })
+        .expect(HttpStatus.CREATED);
+
+      const loginResponse1 = await request(app.getHttpServer())
+        .post('/auth/signin')
+        .send({
+          email: 'user1@example.com',
+          password: 'UserPassword123!',
+        })
+        .expect(HttpStatus.OK);
+
+      const user1Token = loginResponse1.body.data.accessToken;
+      const course = await createCourse(adminToken, 'course', '코스', 50000);
+
+      await addToCart(user1Token, course.id);
+      const orderResponse = await request(app.getHttpServer())
+        .post('/orders')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .expect(HttpStatus.CREATED);
+
+      const orderId = orderResponse.body.data.id;
+
+      // 두 번째 사용자 생성
+      await request(app.getHttpServer())
+        .post('/users')
+        .send({
+          email: 'user2@example.com',
+          password: 'UserPassword123!',
+          nickname: '유저2',
+        })
+        .expect(HttpStatus.CREATED);
+
+      const loginResponse2 = await request(app.getHttpServer())
+        .post('/auth/signin')
+        .send({
+          email: 'user2@example.com',
+          password: 'UserPassword123!',
+        })
+        .expect(HttpStatus.OK);
+
+      const user2Token = loginResponse2.body.data.accessToken;
+
+      // when & then - 두 번째 사용자가 첫 번째 사용자의 주문 취소 시도
+      const response = await request(app.getHttpServer())
+        .delete(`/orders/${orderId}`)
+        .set('Authorization', `Bearer ${user2Token}`)
+        .expect(HttpStatus.FORBIDDEN);
+
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body.error.message).toContain('다른 사용자의 주문은 취소할 수 없습니다');
+    });
+
+    it('인증되지 않은 사용자가 주문 취소 시 401 상태코드를 반환한다', async () => {
+      // when & then
+      await request(app.getHttpServer()).delete('/orders/some-order-id').expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Summary
주문(Order) 및 결제(Payment) API를 구현했습니다. 결제는 Mock으로 구현하여 무조건 성공하도록 했으며, 결제 완료 시 수강 정보가 자동으로 생성됩니다.

## ✨ 주요 변경사항

### 1️⃣ Order API
- **POST /orders** - 장바구니 기반 주문 생성
- **GET /orders** - 주문 목록 조회 (페이지네이션, 상태 필터링)
- **GET /orders/:id** - 주문 상세 조회
- **DELETE /orders/:id** - 주문 취소 (PENDING 상태만)

**특징:**
- OrderItem은 스냅샷 데이터로 저장 (FK 없음)
- 주문 생성 시 장바구니 자동 비우기
- 통합 테스트 17개 작성 (모두 통과 ✅)

### 2️⃣ Payment API (Mock)
- **POST /payments/verify** - 결제 검증 (무조건 성공)
- **POST /payments/webhook** - 결제 웹훅 처리

**특징:**
- Mock으로 구현 (무조건 성공)
- 포트원 연동 대비 필드 구조 준비
- 결제 완료 시 주문 상태 자동 변경 (PENDING → PAID)
- 결제 완료 시 수강 정보(Enrollment) 자동 생성

### 3️⃣ Enrollment 모델
- 수강 정보 관리
- 평생 수강 지원 (expiresAt = null)
- 진행률 및 완료 상태 추적 가능

## 🗄️ 데이터베이스 스키마
- **Order**: 주문 정보
- **OrderItem**: 주문 아이템 (스냅샷)
- **Payment**: 결제 정보 (포트원 연동 대비)
- **Enrollment**: 수강 정보

## 🧪 테스트
- Order API 통합 테스트: 17개 (전체 통과 ✅)
- Payment API: Mock 구현으로 별도 테스트 예정

## 📋 체크리스트
- [x] Order 모델 및 API 구현
- [x] Payment 모델 및 Mock API 구현
- [x] Enrollment 모델 구현
- [x] 결제 완료 시 수강 정보 자동 생성
- [x] 통합 테스트 작성 (Order)
- [x] 빌드 및 린트 확인
- [ ] Payment API 통합 테스트 작성 (추후)

## 🔗 관련 이슈
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)